### PR TITLE
[Fix] Sorting by date will sort data correctly now.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -14737,6 +14737,7 @@ __webpack_require__.r(__webpack_exports__);
   },
   methods: {
     initTable: function initTable() {
+      $.fn.dataTable.moment('D MMM YYYY');
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'Blfrtip',

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -51,6 +51,8 @@ export default {
   },
   methods: {
     initTable: function() {
+      $.fn.dataTable.moment('D MMM YYYY');
+
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'Blfrtip',

--- a/vendor/dataTables.datetime-moment.js
+++ b/vendor/dataTables.datetime-moment.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-undef */
+/**
+ * This plug-in for DataTables represents the ultimate option in extensibility
+ * for sorting date / time strings correctly. It uses
+ * [Moment.js](http://momentjs.com) to create automatic type detection and
+ * sorting plug-ins for DataTables based on a given format. This way, DataTables
+ * will automatically detect your temporal information and sort it correctly.
+ *
+ * For usage instructions, please see the DataTables blog
+ * post that [introduces it](//datatables.net/blog/2014-12-18).
+ *
+ * @name Ultimate Date / Time sorting
+ * @summary Sort date and time in any format using Moment.js
+ * @author [Allan Jardine](//datatables.net)
+ * @depends DataTables 1.10+, Moment.js 1.7+
+ *
+ * @example
+ *    $.fn.dataTable.moment( 'HH:mm MMM D, YY' );
+ *    $.fn.dataTable.moment( 'dddd, MMMM Do, YYYY' );
+ *
+ *    $('#example').DataTable();
+ */
+
+(function(factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery', 'moment', 'datatables.net'], factory);
+  } else {
+    factory(jQuery, moment);
+  }
+}(function($, moment) {
+  $.fn.dataTable.moment = function( format, locale, reverseEmpties ) {
+    var types = $.fn.dataTable.ext.type;
+
+    // Add type detection
+    types.detect.unshift( function( d ) {
+      if ( d ) {
+        // Strip HTML tags and newline characters if possible
+        if ( d.replace ) {
+          d = d.replace(/(<.*?>)|(\r?\n|\r)/g, '');
+        }
+
+        // Strip out surrounding white space
+        d = $.trim( d );
+      }
+
+      // Null and empty values are acceptable
+      if ( d === '' || d === null ) {
+        return 'moment-' + format;
+      }
+
+      return moment( d, format, locale, true ).isValid() ?
+        'moment-' + format :
+        null;
+    } );
+
+    // Add sorting method - use an integer for the sorting
+    types.order[ 'moment-' + format + '-pre' ] = function( d ) {
+      if ( d ) {
+        // Strip HTML tags and newline characters if possible
+        if ( d.replace ) {
+          d = d.replace(/(<.*?>)|(\r?\n|\r)/g, '');
+        }
+
+        // Strip out surrounding white space
+        d = $.trim( d );
+      }
+
+      // eslint-disable-next-line no-nested-ternary
+      return !moment(d, format, locale, true).isValid() ?
+        (reverseEmpties ? -Infinity : Infinity) :
+        parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
+    };
+  };
+}));

--- a/widget.json
+++ b/widget.json
@@ -25,6 +25,7 @@
       "vendor/dataTables.responsive.min.js",
       "vendor/dataTables.buttons.js",
       "vendor/dataTables.buttons.html5.min.js",
+      "vendor/dataTables.datetime-moment.js",
       "vendor/jszip.min.js",
       "vendor/pdfmake.min.js",
       "vendor/vfs_fonts.js",


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6666

## Description
Sorting by date will sort data correctly now.

## Screenshots/screencasts
https://share.getcloudapp.com/DOuA661R

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Added `dataTables` plugin to allow sort columns with moment js help.
Took plugin from [here](https://datatables.net/blog/2014-12-18).