### PR TITLE
[Fix] Now users will see correct sorting even if date fields start with dashes.

### DIFF
--- a/vendor/dataTables.datetime-moment.js
+++ b/vendor/dataTables.datetime-moment.js
@@ -43,8 +43,7 @@
         d = $.trim( d );
       }
 
-      // Null and empty values are acceptable
-      if ( d === '' || d === null ) {
+      if ( d === '' || d === null || d === '—' ) {
         return 'moment-' + format;
       }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-654755085

## Description
Now users will see correct sorting even if date fields start with dashes.

## Screenshots/screencasts
https://share.getcloudapp.com/E0uzmeNO

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This issue occurred because we were replacing `null` value with `—` and the plugin doesn't mark that fields as moment sorting type. 
That is why we have added `—` to the if statement for correct sorting by date.