### PR TITLE
[Fix] Showing loader right after interface HTML is loaded.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -13623,9 +13623,7 @@ var render = function() {
       _vm._v(" "),
       this.isLoading
         ? _c("div", { staticClass: "spinner-holder animated" }, [
-            _c("div", { staticClass: "spinner-overlay" }, [
-              _vm._v("Loading...")
-            ]),
+            _c("div", { staticClass: "spinner-overlay" }),
             _vm._v(" "),
             _c("p", [_vm._v("Loading...")])
           ])

--- a/interface.html
+++ b/interface.html
@@ -1,1 +1,6 @@
-<div id="organization-dashboard"></div>
+<div id="organization-dashboard">
+  <div class="spinner-holder animated">
+    <div class="spinner-overlay"></div>
+    <p style="text-align:center;">Loading...</p>
+  </div>
+</div>

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -2,7 +2,7 @@
   <div class="org-usage-dashboard">
     <RangeDatePicker :onChange="loadData" :isEnabled="!isLoading" v-if="showDatePicker"></RangeDatePicker>
     <div v-if="this.isLoading" class="spinner-holder animated">
-      <div class="spinner-overlay">Loading...</div>
+      <div class="spinner-overlay"></div>
       <p>Loading...</p>
     </div>
     <div v-else-if="this.hasError">


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-654755085

## Description
Showing loader right after interface HTML is loaded.

## Screenshots/screencasts
https://share.getcloudapp.com/7KumXOpD

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko