### PR TITLE
[Fix] Users will get the correct sort order in fields where we compare data.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -14742,6 +14742,7 @@ __webpack_require__.r(__webpack_exports__);
   methods: {
     initTable: function initTable() {
       $.fn.dataTable.moment('D MMM YYYY');
+      $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'Blfrtip',

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -52,6 +52,7 @@ export default {
   methods: {
     initTable: function() {
       $.fn.dataTable.moment('D MMM YYYY');
+      $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
 
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,

--- a/vendor/dataTables.numString.js
+++ b/vendor/dataTables.numString.js
@@ -1,0 +1,24 @@
+$.fn.dataTable.numString = function(format) {
+  // This is the type detection plug in
+  $.fn.dataTable.ext.type.detect.unshift(function(data) {
+    if (typeof data !== 'string') {
+      return null;
+    }
+
+    if (data.match(format)) {
+      return 'numString-' + format.source;
+    }
+
+    return null;
+  });
+
+  // This is the ordering plug in
+  $.fn.dataTable.ext.type.order[
+    'numString-' + format.source + '-pre'
+  ] = function(data) {
+    var num = data.replace(/\D/g, '');
+
+    return num * 1;
+  };
+  // end plug-in
+};

--- a/widget.json
+++ b/widget.json
@@ -26,6 +26,7 @@
       "vendor/dataTables.buttons.js",
       "vendor/dataTables.buttons.html5.min.js",
       "vendor/dataTables.datetime-moment.js",
+      "vendor/dataTables.numString.js",
       "vendor/jszip.min.js",
       "vendor/pdfmake.min.js",
       "vendor/vfs_fonts.js",


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6744

## Description
Users will get the correct sort order in fields where we compare data.

## Screenshots/screencasts
https://share.getcloudapp.com/KouBKPoD

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
To sort numbers in the string correctly used this [plugin](https://datatables.net/plug-ins/sorting/numString).