### PR TITLE
[Fix] Organization dashboard ui fixes 

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -3,6 +3,8 @@ body {
 
 .org-usage-dashboard {
   overflow: hidden; }
+  .org-usage-dashboard .highcharts-button-box {
+    fill: transparent; }
   .org-usage-dashboard .spinner-holder p {
     text-align: center; }
   .org-usage-dashboard .analytics-container, .org-usage-dashboard .tabs {
@@ -41,7 +43,8 @@ body {
   border-right: 1px solid rgba(0, 0, 0, 0.1); }
   .summary-cell h2 {
     margin-top: 10px;
-    font-size: 34px; }
+    font-size: 34px;
+    color: #474974; }
   .summary-cell small {
     display: block;
     font-size: 10px; }
@@ -105,7 +108,7 @@ body {
   .dataTable .dataTables_wrapper .dt-buttons button {
     float: right;
     position: relative;
-    top: -48px;
+    top: -57px;
     margin-right: 15px;
     text-transform: uppercase;
     font-size: 12px;
@@ -117,7 +120,8 @@ body {
     border-radius: 100px;
     padding: 10px 16px;
     border-color: #eae9ec;
-    border: none; }
+    border: none;
+    outline: none; }
     .dataTable .dataTables_wrapper .dt-buttons button:hover {
       background-color: #474974;
       color: white;

--- a/src/scss/dataTable.scss
+++ b/src/scss/dataTable.scss
@@ -29,7 +29,7 @@
     button {
       float: right;
       position: relative;
-      top: -48px;
+      top: -57px;
       margin-right: 15px;
       text-transform: uppercase;
       font-size: 12px;
@@ -42,6 +42,7 @@
       padding: 10px 16px;
       border-color: rgb(234, 233, 236);
       border: none;
+      outline: none;
 
       &:hover {
         background-color: rgb(71, 73, 116);

--- a/src/scss/orgUsageDashboard.scss
+++ b/src/scss/orgUsageDashboard.scss
@@ -5,6 +5,10 @@ body {
 .org-usage-dashboard {
   overflow: hidden;
 
+  .highcharts-button-box {
+    fill: transparent;
+  }
+
   .spinner-holder p {
       text-align: center;
   }

--- a/src/scss/summaryCell.scss
+++ b/src/scss/summaryCell.scss
@@ -6,6 +6,7 @@
   h2 {
     margin-top: 10px;
     font-size: 34px;
+    color: #474974; 
   }
 
   small {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712

## Description
Fixes the next points from the issue mentioned above.

 Clicking the Export CSV and Excel buttons shouldn't add a black outline
 The numbers with the colour RGB(20, 80, 94) should have the #474974 - $brand-text-color
 Apps and users button tabs have a different height compared to the Export buttons
 Remove the white background on the Hamburger icon in the graph

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko