### PR TITLE
[Fix] Fixed sorting of the `sessions` and alike columns.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -14863,7 +14863,7 @@ __webpack_require__.r(__webpack_exports__);
   methods: {
     initTable: function initTable() {
       $.fn.dataTable.moment('D MMM YYYY');
-      $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
+      $.fn.dataTable.numString(/^<div><div class="multiline-cell">/);
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'Blfrtip',
@@ -14963,7 +14963,16 @@ var render = function() {
       ? _c("span", [_vm._v(_vm._s(this.transformDate(_vm.cellValue)))])
       : _vm.cellType === "dynamic"
       ? _c("div", { staticClass: "multiline-cell" }, [
-          _c("p", [_vm._v(_vm._s(_vm.cellValue[0].toLocaleString("en")))]),
+          _c(
+            "p",
+            {
+              staticClass: "order-value",
+              attrs: {
+                "data-orderValue": _vm.cellValue[0].toLocaleString("en")
+              }
+            },
+            [_vm._v(_vm._s(_vm.cellValue[0].toLocaleString("en")))]
+          ),
           _vm._v(" "),
           _vm.cellValue[0] === _vm.cellValue[1]
             ? _c("small", [_vm._v("(" + _vm._s(_vm.perсent) + ")")])

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -52,7 +52,7 @@ export default {
   methods: {
     initTable: function() {
       $.fn.dataTable.moment('D MMM YYYY');
-      $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
+      $.fn.dataTable.numString(/^<div><div class="multiline-cell">/);
 
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,

--- a/src/components/tables/DataTableCell.vue
+++ b/src/components/tables/DataTableCell.vue
@@ -3,7 +3,7 @@
     <span v-if="!cellValue && cellValue !== 0">—</span>
     <span v-else-if="cellType === 'date'">{{ this.transformDate(cellValue) }}</span>
     <div v-else-if="cellType === 'dynamic'" class="multiline-cell">
-      <p>{{ cellValue[0].toLocaleString('en') }}</p>
+      <p :data-orderValue="cellValue[0].toLocaleString('en')" class="order-value">{{ cellValue[0].toLocaleString('en') }}</p>
       <small v-if="cellValue[0] === cellValue[1]">({{ perсent }})</small>
       <small v-else-if="cellValue[0] > cellValue[1]" class="text-success">(&#8593;{{ this.perсent }})</small>
       <small v-else class="text-danger">(&#8595;{{ this.perсent }})</small>

--- a/vendor/dataTables.numString.js
+++ b/vendor/dataTables.numString.js
@@ -16,9 +16,7 @@ $.fn.dataTable.numString = function(format) {
   $.fn.dataTable.ext.type.order[
     'numString-' + format.source + '-pre'
   ] = function(data) {
-    var num = data.replace(/\D/g, '');
-
-    return num * 1;
+    return $(data).find('.order-value').data('ordervalue') * 1;
   };
   // end plug-in
 };


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-665568565

## Description
Fixed sorting of the `sessions` and alike columns.

## Screenshots/screencasts
https://share.getcloudapp.com/L1uJ5ggv

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This fix is for these issues.
> Sorting of all columns does not work - it is currently doing it based on the first number (Logged in as Peter Van Eijk Clifford Chance). See the recording

>Sorting by session count doesn't work correctly: https://share.getcloudapp.com/L1up8Z1Q