### PR TITLE
[Fix] Show date according to the local format

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -14862,7 +14862,7 @@ __webpack_require__.r(__webpack_exports__);
   },
   methods: {
     initTable: function initTable() {
-      $.fn.dataTable.moment(moment().creationData().locale._longDateFormat.LL);
+      $.fn.dataTable.moment(moment.localeData().longDateFormat('ll'));
       $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,

--- a/dist/app.js
+++ b/dist/app.js
@@ -14862,7 +14862,7 @@ __webpack_require__.r(__webpack_exports__);
   },
   methods: {
     initTable: function initTable() {
-      $.fn.dataTable.moment('D MMM YYYY');
+      $.fn.dataTable.moment(moment().creationData().locale._longDateFormat.LL);
       $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
       this.component = $(this.$refs.table).DataTable({
         scrollX: true,
@@ -15065,7 +15065,7 @@ __webpack_require__.r(__webpack_exports__);
   },
   methods: {
     transformDate: function transformDate(date) {
-      return moment(date).format('D MMM YYYY');
+      return moment(date).format(moment().creationData().locale._longDateFormat.LL);
     },
     openUserProfile: function openUserProfile(options) {
       Fliplet.Studio.emit('overlay', {

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -51,7 +51,7 @@ export default {
   },
   methods: {
     initTable: function() {
-      $.fn.dataTable.moment('D MMM YYYY');
+      $.fn.dataTable.moment(moment().creationData().locale._longDateFormat.LL);
       $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
 
       this.component = $(this.$refs.table).DataTable({

--- a/src/components/tables/DataTable.vue
+++ b/src/components/tables/DataTable.vue
@@ -51,7 +51,7 @@ export default {
   },
   methods: {
     initTable: function() {
-      $.fn.dataTable.moment(moment().creationData().locale._longDateFormat.LL);
+      $.fn.dataTable.moment(moment.localeData().longDateFormat('ll'));
       $.fn.dataTable.numString(/^<div><div class="multiline-cell"><p>\d+<\/p>/);
 
       this.component = $(this.$refs.table).DataTable({

--- a/src/components/tables/DataTableCell.vue
+++ b/src/components/tables/DataTableCell.vue
@@ -42,7 +42,7 @@ export default {
   },
   methods: {
     transformDate: function(date) {
-      return moment(date).format('D MMM YYYY');
+      return moment(date).format(moment().creationData().locale._longDateFormat.LL);
     },
     openUserProfile: function(options) {
       Fliplet.Studio.emit('overlay', {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-665568565

## Description
Show date according to the local format

## Screenshots/screencasts
https://share.getcloudapp.com/p9uGnKKJ

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Fix is for this issue.
> Date range selector should use the same style fonts as the date data in the table
see the info of 2 last items in the comment