### PR TITLE
[Fix] Users will see all content after the overlay close

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -13791,6 +13791,15 @@ __webpack_require__.r(__webpack_exports__);
         _this.isLoading = false;
         _this.showDatePicker = true;
       });
+    },
+    init: function init() {
+      Fliplet.Studio.onMessage(function (event) {
+        if (event.data && event.data.event === 'overlay-close') {
+          setTimeout(function () {
+            Fliplet.Widget.autosize();
+          }, 500);
+        }
+      });
     }
   },
   created: function created() {
@@ -13799,6 +13808,7 @@ __webpack_require__.r(__webpack_exports__);
   mounted: function mounted() {
     var startDate = moment().add(-1, 'month');
     var endDate = moment();
+    this.init();
     this.loadData(startDate, endDate);
     Fliplet.Widget.autosize();
   },

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -68,6 +68,15 @@ export default {
           this.isLoading = false;
           this.showDatePicker = true;
         });
+    },
+    init: function() {
+      Fliplet.Studio.onMessage(function(event) {
+        if (event.data && event.data.event === 'overlay-close') {
+          setTimeout(() => {
+            Fliplet.Widget.autosize();
+          }, 500);
+        }
+      });
     }
   },
   created() {
@@ -77,6 +86,7 @@ export default {
     const startDate = moment().add(-1, 'month');
     const endDate = moment();
 
+    this.init();
     this.loadData(startDate, endDate);
     Fliplet.Widget.autosize();
   },


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-665568565

## Description
Users will see all content after the overlay close

## Screenshots/screencasts
https://share.getcloudapp.com/Jru6lWEK

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Fix is for this issue.
> [Blocking] Click on an app to see the app analytics, then close the overlay, you will notice that now you can't get to the bottom of the table. See the recording