### PR TITLE
[Fix] Added alert to inform users that sessions data available only from June 24th, 2020

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -13650,6 +13650,22 @@ var render = function() {
                 attrs: { analyticsData: this.analyticsData.stats }
               }),
               _vm._v(" "),
+              _c("AlertMessage", {
+                directives: [
+                  {
+                    name: "show",
+                    rawName: "v-show",
+                    value: this.isStartDateBeforehand,
+                    expression: "this.isStartDateBeforehand"
+                  }
+                ],
+                staticClass: "component",
+                attrs: {
+                  message:
+                    "<b>Studio sessions</b> data is only avaliable from June 24th 2020"
+                }
+              }),
+              _vm._v(" "),
               _c("ul", { staticClass: "tabs" }, [
                 _c(
                   "li",
@@ -13725,6 +13741,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _services_analytics__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(398);
 /* harmony import */ var _components_AnalyticsChart__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(436);
 /* harmony import */ var _components_tables_UsersDataTable__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(441);
+/* harmony import */ var _components_AlertMessage__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(446);
 //
 //
 //
@@ -13751,6 +13768,8 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+
 
 
 
@@ -13765,7 +13784,8 @@ __webpack_require__.r(__webpack_exports__);
       errorMessage: '',
       hasError: false,
       activeTab: 'apps',
-      showDatePicker: false
+      showDatePicker: false,
+      isStartDateBeforehand: false
     };
   },
   components: {
@@ -13773,13 +13793,15 @@ __webpack_require__.r(__webpack_exports__);
     AppDataTable: _components_tables_AppsDataTable__WEBPACK_IMPORTED_MODULE_1__["default"],
     RangeDatePicker: _components_RangeDatePicker_vue__WEBPACK_IMPORTED_MODULE_2__["default"],
     AnalyticsChart: _components_AnalyticsChart__WEBPACK_IMPORTED_MODULE_4__["default"],
-    UsersDataTable: _components_tables_UsersDataTable__WEBPACK_IMPORTED_MODULE_5__["default"]
+    UsersDataTable: _components_tables_UsersDataTable__WEBPACK_IMPORTED_MODULE_5__["default"],
+    AlertMessage: _components_AlertMessage__WEBPACK_IMPORTED_MODULE_6__["default"]
   },
   methods: {
     loadData: function loadData(startDate, endDate) {
       var _this = this;
 
       this.isLoading = true;
+      this.isStartDateBeforehand = moment(startDate).isBefore('2020-06-24');
       Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["default"])(startDate, endDate).then(function (result) {
         result.appSessions = Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["handleSessions"])(startDate, endDate, result.appSessions);
         result.studioSessions = Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["handleSessions"])(startDate, endDate, result.studioSessions);
@@ -16517,6 +16539,102 @@ __webpack_require__.r(__webpack_exports__);
   mounted: function mounted() {
     this.transformData();
     Fliplet.Widget.autosize();
+  }
+});
+
+/***/ }),
+/* 446 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(447);
+/* harmony import */ var _AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(449);
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(397);
+
+
+
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "src/components/AlertMessage.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+/* 447 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(448);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+/* 448 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", {
+    class: ["alert", _vm.alertClass],
+    domProps: { innerHTML: _vm._s(_vm.message) }
+  })
+}
+var staticRenderFns = []
+render._withStripped = true
+
+
+
+/***/ }),
+/* 449 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(450);
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+/* 450 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+/* harmony default export */ __webpack_exports__["default"] = ({
+  props: {
+    message: String,
+    alertClass: {
+      type: String,
+      "default": 'alert-warning'
+    }
   }
 });
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -13662,7 +13662,7 @@ var render = function() {
                 staticClass: "component",
                 attrs: {
                   message:
-                    "<b>Studio sessions</b> data is only avaliable from June 24th 2020"
+                    "Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020."
                 }
               }),
               _vm._v(" "),

--- a/dist/app.js
+++ b/dist/app.js
@@ -13655,14 +13655,14 @@ var render = function() {
                   {
                     name: "show",
                     rawName: "v-show",
-                    value: this.isStartDateBeforehand,
-                    expression: "this.isStartDateBeforehand"
+                    value: this.isDataPartiallyAvailable,
+                    expression: "this.isDataPartiallyAvailable"
                   }
                 ],
                 staticClass: "component",
                 attrs: {
                   message:
-                    "Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020."
+                    "Data for <b>studio sessions, new studio users/<b> and <b>apps edited</b> are only available from June 24th 2020."
                 }
               }),
               _vm._v(" "),
@@ -13785,7 +13785,7 @@ __webpack_require__.r(__webpack_exports__);
       hasError: false,
       activeTab: 'apps',
       showDatePicker: false,
-      isStartDateBeforehand: false
+      isDataPartiallyAvailable: false
     };
   },
   components: {
@@ -13801,7 +13801,7 @@ __webpack_require__.r(__webpack_exports__);
       var _this = this;
 
       this.isLoading = true;
-      this.isStartDateBeforehand = moment(startDate).isBefore('2020-06-24');
+      this.isDataPartiallyAvailable = moment(startDate).isBefore('2020-06-24');
       Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["default"])(startDate, endDate).then(function (result) {
         result.appSessions = Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["handleSessions"])(startDate, endDate, result.appSessions);
         result.studioSessions = Object(_services_analytics__WEBPACK_IMPORTED_MODULE_3__["handleSessions"])(startDate, endDate, result.studioSessions);

--- a/dist/app.js
+++ b/dist/app.js
@@ -13650,7 +13650,7 @@ var render = function() {
                 attrs: { analyticsData: this.analyticsData.stats }
               }),
               _vm._v(" "),
-              _c("AlertMessage", {
+              _c("Message", {
                 directives: [
                   {
                     name: "show",
@@ -13741,7 +13741,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _services_analytics__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(398);
 /* harmony import */ var _components_AnalyticsChart__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(436);
 /* harmony import */ var _components_tables_UsersDataTable__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(441);
-/* harmony import */ var _components_AlertMessage__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(446);
+/* harmony import */ var _components_Message__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(446);
 //
 //
 //
@@ -13794,7 +13794,7 @@ __webpack_require__.r(__webpack_exports__);
     RangeDatePicker: _components_RangeDatePicker_vue__WEBPACK_IMPORTED_MODULE_2__["default"],
     AnalyticsChart: _components_AnalyticsChart__WEBPACK_IMPORTED_MODULE_4__["default"],
     UsersDataTable: _components_tables_UsersDataTable__WEBPACK_IMPORTED_MODULE_5__["default"],
-    AlertMessage: _components_AlertMessage__WEBPACK_IMPORTED_MODULE_6__["default"]
+    Message: _components_Message__WEBPACK_IMPORTED_MODULE_6__["default"]
   },
   methods: {
     loadData: function loadData(startDate, endDate) {
@@ -16548,8 +16548,8 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(447);
-/* harmony import */ var _AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(449);
+/* harmony import */ var _Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(447);
+/* harmony import */ var _Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(449);
 /* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(397);
 
 
@@ -16559,9 +16559,9 @@ __webpack_require__.r(__webpack_exports__);
 /* normalize component */
 
 var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
-  _AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
-  _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["render"],
-  _AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  _Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
   false,
   null,
   null,
@@ -16571,7 +16571,7 @@ var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_
 
 /* hot reload */
 if (false) { var api; }
-component.options.__file = "src/components/AlertMessage.vue"
+component.options.__file = "src/components/Message.vue"
 /* harmony default export */ __webpack_exports__["default"] = (component.exports);
 
 /***/ }),
@@ -16580,10 +16580,10 @@ component.options.__file = "src/components/AlertMessage.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(448);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(448);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_template_id_9185b48a___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_61d2d687___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -16600,7 +16600,7 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("div", {
-    class: ["alert", _vm.alertClass],
+    class: ["alert", _vm.type],
     domProps: { innerHTML: _vm._s(_vm.message) }
   })
 }
@@ -16615,8 +16615,8 @@ render._withStripped = true
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(450);
-/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_AlertMessage_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(450);
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_5_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
 
 /***/ }),
 /* 450 */
@@ -16631,7 +16631,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
     message: String,
-    alertClass: {
+    type: {
       type: String,
       "default": 'alert-warning'
     }

--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -151,3 +151,6 @@ body {
       text-align: center; }
       .dataTable .table-responsive .multiline-cell small {
         display: block; }
+
+.alert {
+  margin-top: 10px; }

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -11,7 +11,7 @@
     <div v-else-if="Object.keys(this.analyticsData).length > 0">
       <AnalyticsChart class="component" :appsSessions="this.analyticsData.appSessions" :studioSessions="this.analyticsData.studioSessions"></AnalyticsChart>
       <AnalyticsSummary class="component" :analyticsData="this.analyticsData.stats"></AnalyticsSummary>
-      <Message v-show="this.isStartDateBeforehand" class="component" message='Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020.' />
+      <Message v-show="this.isDataPartiallyAvailable" class="component" message='Data for <b>studio sessions, new studio users/<b> and <b>apps edited</b> are only available from June 24th 2020.' />
       <ul class="tabs">
         <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Apps</li>
         <li role="presentation" @click="activeTab = 'users'" :class="{active: activeTab === 'users'}">Users</li>
@@ -43,7 +43,7 @@ export default {
       hasError: false,
       activeTab: 'apps',
       showDatePicker: false,
-      isStartDateBeforehand: false
+      isDataPartiallyAvailable: false
     };
   },
   components: {
@@ -57,7 +57,7 @@ export default {
   methods: {
     loadData: function(startDate, endDate) {
       this.isLoading = true;
-      this.isStartDateBeforehand = moment(startDate).isBefore('2020-06-24');
+      this.isDataPartiallyAvailable = moment(startDate).isBefore('2020-06-24');
 
       getAnalyticsData(startDate, endDate)
         .then(result => {

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -11,7 +11,7 @@
     <div v-else-if="Object.keys(this.analyticsData).length > 0">
       <AnalyticsChart class="component" :appsSessions="this.analyticsData.appSessions" :studioSessions="this.analyticsData.studioSessions"></AnalyticsChart>
       <AnalyticsSummary class="component" :analyticsData="this.analyticsData.stats"></AnalyticsSummary>
-      <AlertMessage v-show="this.isStartDateBeforehand" class="component" message='Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020.' />
+      <Message v-show="this.isStartDateBeforehand" class="component" message='Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020.' />
       <ul class="tabs">
         <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Apps</li>
         <li role="presentation" @click="activeTab = 'users'" :class="{active: activeTab === 'users'}">Users</li>
@@ -32,7 +32,7 @@ import RangeDatePicker from './components/RangeDatePicker.vue';
 import getAnalyticsData, { handleSessions } from './services/analytics';
 import AnalyticsChart from './components/AnalyticsChart';
 import UsersDataTable from './components/tables/UsersDataTable';
-import AlertMessage from './components/AlertMessage';
+import Message from './components/Message';
 
 export default {
   data() {
@@ -52,7 +52,7 @@ export default {
     RangeDatePicker,
     AnalyticsChart,
     UsersDataTable,
-    AlertMessage
+    Message
   },
   methods: {
     loadData: function(startDate, endDate) {

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -11,7 +11,7 @@
     <div v-else-if="Object.keys(this.analyticsData).length > 0">
       <AnalyticsChart class="component" :appsSessions="this.analyticsData.appSessions" :studioSessions="this.analyticsData.studioSessions"></AnalyticsChart>
       <AnalyticsSummary class="component" :analyticsData="this.analyticsData.stats"></AnalyticsSummary>
-      <AlertMessage v-show="this.isStartDateBeforehand" class="component" message='<b>Studio sessions</b> data is only avaliable from June 24th 2020' />
+      <AlertMessage v-show="this.isStartDateBeforehand" class="component" message='Data for <b>studio sessions, new studio users and apps edited</b> are only available from June 24th 2020.' />
       <ul class="tabs">
         <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Apps</li>
         <li role="presentation" @click="activeTab = 'users'" :class="{active: activeTab === 'users'}">Users</li>

--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -11,6 +11,7 @@
     <div v-else-if="Object.keys(this.analyticsData).length > 0">
       <AnalyticsChart class="component" :appsSessions="this.analyticsData.appSessions" :studioSessions="this.analyticsData.studioSessions"></AnalyticsChart>
       <AnalyticsSummary class="component" :analyticsData="this.analyticsData.stats"></AnalyticsSummary>
+      <AlertMessage v-show="this.isStartDateBeforehand" class="component" message='<b>Studio sessions</b> data is only avaliable from June 24th 2020' />
       <ul class="tabs">
         <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Apps</li>
         <li role="presentation" @click="activeTab = 'users'" :class="{active: activeTab === 'users'}">Users</li>
@@ -31,6 +32,7 @@ import RangeDatePicker from './components/RangeDatePicker.vue';
 import getAnalyticsData, { handleSessions } from './services/analytics';
 import AnalyticsChart from './components/AnalyticsChart';
 import UsersDataTable from './components/tables/UsersDataTable';
+import AlertMessage from './components/AlertMessage';
 
 export default {
   data() {
@@ -40,7 +42,8 @@ export default {
       errorMessage: '',
       hasError: false,
       activeTab: 'apps',
-      showDatePicker: false
+      showDatePicker: false,
+      isStartDateBeforehand: false
     };
   },
   components: {
@@ -48,11 +51,13 @@ export default {
     AppDataTable,
     RangeDatePicker,
     AnalyticsChart,
-    UsersDataTable
+    UsersDataTable,
+    AlertMessage
   },
   methods: {
     loadData: function(startDate, endDate) {
       this.isLoading = true;
+      this.isStartDateBeforehand = moment(startDate).isBefore('2020-06-24');
 
       getAnalyticsData(startDate, endDate)
         .then(result => {

--- a/src/components/AlertMessage.vue
+++ b/src/components/AlertMessage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div :class="['alert', alertClass]" v-html="message"></div>
+</template>
+
+<script>
+export default {
+  props: {
+    message: String,
+    alertClass: {
+      type: String,
+      default: 'alert-warning'
+    }
+  }
+};
+</script>

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -1,12 +1,12 @@
 <template>
-  <div :class="['alert', alertClass]" v-html="message"></div>
+  <div :class="['alert', type]" v-html="message"></div>
 </template>
 
 <script>
 export default {
   props: {
     message: String,
-    alertClass: {
+    type: {
       type: String,
       default: 'alert-warning'
     }

--- a/src/scss/alertMessage.scss
+++ b/src/scss/alertMessage.scss
@@ -1,0 +1,3 @@
+.alert {
+    margin-top: 10px;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,3 +4,4 @@
 @import "rangeDatePicker";
 @import "dateDropdown";
 @import "dataTable";
+@import "alertMessage";


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6712#issuecomment-665568565

## Description
Added alert to inform users that sessions data available only from June 24th, 2020

## Screenshots/screencasts
https://share.getcloudapp.com/v1u26eGd

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Fix is for this issue.
> If the date range starts from before June 24th 2020, add a ".alert.alert-warning" dialog under the table. https://share.getcloudapp.com/7KuL1WL7 (June 24th 2020 is the same for all users. Compare this with the start date of the seleted dashboard date range.)