### PR TITLE
feat: rename apps → projects (v3 user-visible wording)

### DIFF
--- a/src/OrgUsageDashboard.vue
+++ b/src/OrgUsageDashboard.vue
@@ -12,10 +12,10 @@
       <AnalyticsChart class="component" :appsSessions="this.analyticsData.appSessions" :studioSessions="this.analyticsData.studioSessions"></AnalyticsChart>
       <AnalyticsSummary class="component" :analyticsData="this.analyticsData.stats"></AnalyticsSummary>
       <Message v-show="this.isDataPartiallyAvailable" class="component">
-        Data for <b>studio sessions, new studio users</b> and <b>apps edited</b> are only available from June 24th 2020.
+        Data for <b>studio sessions, new studio users</b> and <b>projects edited</b> are only available from June 24th 2020.
       </Message>
       <ul class="tabs">
-        <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Apps</li>
+        <li role="presentation" @click="activeTab = 'apps'" :class="{active: activeTab === 'apps'}">Projects</li>
         <li role="presentation" @click="activeTab = 'users'" :class="{active: activeTab === 'users'}">Users</li>
       </ul>
       <AppDataTable v-if="activeTab === 'apps'" class="component" :apps="this.analyticsData.apps" :startDate="this.startDate" :endDate="this.endDate"></AppDataTable>

--- a/src/components/AnalyticsChart.vue
+++ b/src/components/AnalyticsChart.vue
@@ -59,7 +59,7 @@ export default {
         },
         series: [
           {
-            name: 'Apps Sessions',
+            name: 'Sessions',
             color: '#43ccf0',
             fillColor: 'rgba(67,204,240,0.4)',
             type: 'areaspline',

--- a/src/components/AnalyticsSummary.vue
+++ b/src/components/AnalyticsSummary.vue
@@ -28,31 +28,31 @@ export default {
           'The total number of Studio users that logged in for the first time.'
         ],
         ['studioUsers', 'Studio users', 'The total number of Studio users.'],
-        ['appsCreated', 'Apps created', 'The total number of apps created.'],
+        ['appsCreated', 'Projects created', 'The total number of projects created.'],
         [
           'appsEdited',
-          'Apps edited',
-          'The total number of apps that had screens altered within Studio.'
+          'Projects edited',
+          'The total number of projects that had screens altered within Studio.'
         ],
         [
           'appsPublished',
-          'Apps published',
-          'The total number of apps that had app updates published via Studio.'
+          'Projects published',
+          'The total number of projects that had updates published via Studio.'
         ],
         [
           'appSessions',
-          'App sessions',
-          'The total number of app sessions. A session is a group of interactions without 30 min of inactivity.'
+          'Sessions',
+          'The total number of sessions. A session is a group of interactions without 30 min of inactivity.'
         ],
         [
           'totalAppUsers',
-          'Total app users',
-          'Total app users across all apps. A user is a unique device and, if the app has a login, a unique logged in user.'
+          'Total users',
+          'Total users across all projects. A user is a unique device and, if the project has a login, a unique logged in user.'
         ],
         [
           'uniqueAppUsers',
-          'Unique app users',
-          'Total app users excluding duplicate visits from authenticated users.'
+          'Unique users',
+          'Total users excluding duplicate visits from authenticated users.'
         ]
       ]
     };

--- a/src/components/tables/AppsDataTable.vue
+++ b/src/components/tables/AppsDataTable.vue
@@ -14,12 +14,12 @@ export default {
     return {
       cols: [
         {
-          name: 'App',
+          name: 'Project',
           help: ''
         },
         {
           name: 'Created',
-          help: 'The date the app was created in Studio'
+          help: 'The date the project was created in Studio'
         },
         {
           name: 'Last edit',
@@ -27,19 +27,19 @@ export default {
         },
         {
           name: 'Last publish',
-          help: 'The date an app update was last published in Studio'
+          help: 'The date a project update was last published in Studio'
         },
         {
           name: 'Apple',
-          help: 'The first time an app was built for iOS'
+          help: 'The first time a project was built for iOS'
         },
         {
           name: 'Android',
-          help: 'The first time an app was built for Android'
+          help: 'The first time a project was built for Android'
         },
         {
           name: 'Web',
-          help: 'The first time an app was published to web'
+          help: 'The first time a project was published to web'
         },
         {
           name: 'Users',
@@ -51,7 +51,7 @@ export default {
         },
         {
           name: 'Sessions',
-          help: 'The total number of app sessions.\n A session is a group of interactions without 30 min of inactivity.'
+          help: 'The total number of sessions.\n A session is a group of interactions without 30 min of inactivity.'
         },
         {
           name: 'Edits',
@@ -59,7 +59,7 @@ export default {
         },
         {
           name: 'Published',
-          help: 'The total times the an app updated was published in Studio'
+          help: 'The total times a project update was published in Studio'
         }
       ],
       rows: [],

--- a/src/components/tables/DataTableCell.vue
+++ b/src/components/tables/DataTableCell.vue
@@ -18,7 +18,7 @@
     </div>
     <div v-else-if="cellType === 'action'" @click.stop="onCellAction(cellValue)" class="action-holder">
       <span class="link btn-link">{{ cellValue.title }}</span>
-      <Tooltip v-if="'appId' in cellValue" :content="'See app analytics'" :icon="'fa-area-chart'" />
+      <Tooltip v-if="'appId' in cellValue" :content="'See project analytics'" :icon="'fa-area-chart'" />
       <Tooltip v-else :content="'Edit user'" :icon="'fa-pencil'" />
     </div>
     <span v-else>

--- a/src/components/tables/UsersDataTable.vue
+++ b/src/components/tables/UsersDataTable.vue
@@ -34,16 +34,16 @@ export default {
           help: 'The number of Fliplet Viewer sessions the user has. \n A session is a group of interactions without 30 min of inactivity.'
         },
         {
-          name: 'App publishes',
-          help: 'The number of times the user has published an app updated in Studio'
+          name: 'Publishes',
+          help: 'The number of times the user has published a project update in Studio'
         },
         {
-          name: 'Apps available',
-          help: 'The number of apps the user has access to in Studio'
+          name: 'Projects available',
+          help: 'The number of projects the user has access to in Studio'
         },
         {
-          name: 'Apps created',
-          help: 'The number of apps the user has created in Studio'
+          name: 'Projects created',
+          help: 'The number of projects the user has created in Studio'
         }
       ],
       rows: [],

--- a/src/config/sample-data.js
+++ b/src/config/sample-data.js
@@ -165,7 +165,7 @@ const sampleData = {
   },
   apps: [{
     id: 1,
-    name: 'First app',
+    name: 'First project',
     createdAt: moment().subtract(15, 'days').utc().format(),
     updatedAt: moment().subtract(12, 'days').utc().format(),
     publishedAt: moment().subtract(5, 'days').utc().format(),
@@ -196,7 +196,7 @@ const sampleData = {
     }
   }, {
     id: 2,
-    name: 'Second app',
+    name: 'Second project',
     createdAt: moment().subtract(5, 'days').utc().format(),
     updatedAt: moment().subtract(2, 'days').utc().format(),
     publishedAt: null,


### PR DESCRIPTION
## Summary

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope (24 strings across 7 files)

### Renamed to "project"
- Tab "Apps" → "Projects"
- "Apps created" / "Apps edited" / "Apps published" → "Projects …" (+ help text)
- "App" column → "Project"
- "Apps available" / "Apps created" (user table) → "Projects …"
- "App publishes" (user table) → "Publishes" (generic) + help text → "project update"
- "See app analytics" tooltip → "See project analytics"
- Sample row labels "First app" / "Second app" → "First project" / "Second project"

### Generic (qualifier dropped)
- "App sessions" → "Sessions"
- "Total app users" / "Unique app users" → "Total users" / "Unique users"
- Chart series "Apps Sessions" → "Sessions"
- "Total number of app sessions" → "Total number of sessions"

## What was kept

- Data keys: `appsCreated`, `appsEdited`, `appsPublished`, `appSessions`, `totalAppUsers`, `uniqueAppUsers`
- State key `activeTab = 'apps'`
- Overlay route `name: 'app-analytics'`
- Component props (`apps`, `app.name`, etc.)

## Note

Targeting `master` because no `production` branch exists on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)